### PR TITLE
feat: Play welcome audio once on HomeScreen launch for patient app

### DIFF
--- a/features/home/src/patient/kotlin/eg/edu/cu/csds/icare/home/screen/HomeScreen.kt
+++ b/features/home/src/patient/kotlin/eg/edu/cu/csds/icare/home/screen/HomeScreen.kt
@@ -64,6 +64,7 @@ internal fun HomeScreen(
             .getPackageInfo(context.packageName, 0)
             .versionName ?: ""
     var openDialog by homeViewModel.openDialog
+    var isPlayed by homeViewModel.isPlayed
     val userResource by mainViewModel.currentUserFlow.collectAsStateWithLifecycle()
 
     BackHandler {
@@ -71,8 +72,11 @@ internal fun HomeScreen(
     }
 
     userResource.data?.let {
-        LaunchedEffect(key1 = Unit) {
-            mediaHelper.play(R.raw.welcome)
+        LaunchedEffect(key1 = isPlayed) {
+            if (!isPlayed) {
+                mediaHelper.play(R.raw.welcome)
+                isPlayed = true
+            }
         }
     }
 


### PR DESCRIPTION
The `HomeScreen` now plays a welcome audio file (`R.raw.welcome`) only once upon the first launch after the user data is loaded.
- Added a `isPlayed` state variable to `HomeViewModel` to track whether the audio has been played.
- The audio playback logic now checks the `isPlayed` state to ensure the audio plays only once.
- Set `isPlayed` to true after first play to prevent playing the audio again.