### PR TITLE
build: Remove OS-specific keystore path logic

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,9 +1,9 @@
+
 import build.Build
 import build.BuildConfig
 import build.BuildDimensions
 import build.BuildTypes
 import extensions.getLocalProperty
-import extensions.osFamily
 import flavors.FlavorTypes
 import signing.SigningTypes
 import test.TestBuildConfig
@@ -38,7 +38,7 @@ android {
 
     signingConfigs {
         create(SigningTypes.RELEASE) {
-            storeFile = file(project.getLocalProperty("release_key.store.$osFamily"))
+            storeFile = file(project.getLocalProperty("release_key.store"))
             storePassword = project.getLocalProperty("release_key.store_password")
             keyAlias = project.getLocalProperty("release_key.alias")
             keyPassword = project.getLocalProperty("release_key.key_password")
@@ -47,7 +47,7 @@ android {
         }
 
         create(SigningTypes.RELEASE_EXTERNAL_QA) {
-            storeFile = file(project.getLocalProperty("qa_key.store.$osFamily"))
+            storeFile = file(project.getLocalProperty("qa_key.store"))
             storePassword = project.getLocalProperty("qa_key.store_password")
             keyAlias = project.getLocalProperty("qa_key.alias")
             keyPassword = project.getLocalProperty("qa_key.key_password")

--- a/buildSrc/src/main/kotlin/extensions/Extensions.kt
+++ b/buildSrc/src/main/kotlin/extensions/Extensions.kt
@@ -1,6 +1,5 @@
 package extensions
 
-import org.apache.tools.ant.taskdefs.condition.Os
 import org.gradle.api.Project
 import java.util.Properties
 
@@ -17,11 +16,3 @@ fun Project.getLocalProperty(propertyName: String): String {
     return localProperties.getProperty(propertyName)
         ?: throw NoSuchFieldException("Property $propertyName not found in $LOCAL_PROPERTIES_FILE_NAME")
 }
-
-val osFamily: String
-    get() =
-        when {
-            Os.isFamily(Os.FAMILY_WINDOWS) -> Os.FAMILY_WINDOWS
-            Os.isFamily(Os.FAMILY_UNIX) -> Os.FAMILY_UNIX
-            else -> ""
-        }

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -2,7 +2,6 @@ import build.Build
 import build.BuildConfig
 import build.BuildTypes
 import extensions.getLocalProperty
-import extensions.osFamily
 import signing.SigningTypes
 import test.TestBuildConfig
 
@@ -27,7 +26,7 @@ android {
 
     signingConfigs {
         create(SigningTypes.RELEASE) {
-            storeFile = file(project.getLocalProperty("release_key.store.$osFamily"))
+            storeFile = file(project.getLocalProperty("release_key.store"))
             storePassword = project.getLocalProperty("release_key.store_password")
             keyAlias = project.getLocalProperty("release_key.alias")
             keyPassword = project.getLocalProperty("release_key.key_password")
@@ -35,7 +34,7 @@ android {
             enableV2Signing = true
         }
         create(SigningTypes.RELEASE_EXTERNAL_QA) {
-            storeFile = file(project.getLocalProperty("qa_key.store.$osFamily"))
+            storeFile = file(project.getLocalProperty("qa_key.store"))
             storePassword = project.getLocalProperty("qa_key.store_password")
             keyAlias = project.getLocalProperty("qa_key.alias")
             keyPassword = project.getLocalProperty("qa_key.key_password")

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -4,7 +4,6 @@ import build.BuildConfig
 import build.BuildDimensions
 import build.BuildTypes
 import extensions.getLocalProperty
-import extensions.osFamily
 import flavors.FlavorTypes
 import signing.SigningTypes
 import test.TestBuildConfig
@@ -32,7 +31,7 @@ android {
 
     signingConfigs {
         create(SigningTypes.RELEASE) {
-            storeFile = file(project.getLocalProperty("release_key.store.$osFamily"))
+            storeFile = file(project.getLocalProperty("release_key.store"))
             storePassword = project.getLocalProperty("release_key.store_password")
             keyAlias = project.getLocalProperty("release_key.alias")
             keyPassword = project.getLocalProperty("release_key.key_password")
@@ -40,7 +39,7 @@ android {
             enableV2Signing = true
         }
         create(SigningTypes.RELEASE_EXTERNAL_QA) {
-            storeFile = file(project.getLocalProperty("qa_key.store.$osFamily"))
+            storeFile = file(project.getLocalProperty("qa_key.store"))
             storePassword = project.getLocalProperty("qa_key.store_password")
             keyAlias = project.getLocalProperty("qa_key.alias")
             keyPassword = project.getLocalProperty("qa_key.key_password")

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -4,7 +4,6 @@ import build.BuildDimensions
 import build.BuildTypes
 import build.BuildVariables
 import extensions.getLocalProperty
-import extensions.osFamily
 import flavors.FlavorTypes
 import signing.SigningTypes
 import test.TestBuildConfig
@@ -36,7 +35,7 @@ android {
 
     signingConfigs {
         create(SigningTypes.RELEASE) {
-            storeFile = file(project.getLocalProperty("release_key.store.$osFamily"))
+            storeFile = file(project.getLocalProperty("release_key.store"))
             storePassword = project.getLocalProperty("release_key.store_password")
             keyAlias = project.getLocalProperty("release_key.alias")
             keyPassword = project.getLocalProperty("release_key.key_password")
@@ -44,7 +43,7 @@ android {
             enableV2Signing = true
         }
         create(SigningTypes.RELEASE_EXTERNAL_QA) {
-            storeFile = file(project.getLocalProperty("qa_key.store.$osFamily"))
+            storeFile = file(project.getLocalProperty("qa_key.store"))
             storePassword = project.getLocalProperty("qa_key.store_password")
             keyAlias = project.getLocalProperty("qa_key.alias")
             keyPassword = project.getLocalProperty("qa_key.key_password")

--- a/features/admin/build.gradle.kts
+++ b/features/admin/build.gradle.kts
@@ -3,7 +3,6 @@ import build.BuildConfig
 import build.BuildDimensions
 import build.BuildTypes
 import extensions.getLocalProperty
-import extensions.osFamily
 import flavors.FlavorTypes
 import signing.SigningTypes
 import test.TestBuildConfig
@@ -31,7 +30,7 @@ android {
 
     signingConfigs {
         create(SigningTypes.RELEASE) {
-            storeFile = file(project.getLocalProperty("release_key.store.$osFamily"))
+            storeFile = file(project.getLocalProperty("release_key.store"))
             storePassword = project.getLocalProperty("release_key.store_password")
             keyAlias = project.getLocalProperty("release_key.alias")
             keyPassword = project.getLocalProperty("release_key.key_password")
@@ -39,7 +38,7 @@ android {
             enableV2Signing = true
         }
         create(SigningTypes.RELEASE_EXTERNAL_QA) {
-            storeFile = file(project.getLocalProperty("qa_key.store.$osFamily"))
+            storeFile = file(project.getLocalProperty("qa_key.store"))
             storePassword = project.getLocalProperty("qa_key.store_password")
             keyAlias = project.getLocalProperty("qa_key.alias")
             keyPassword = project.getLocalProperty("qa_key.key_password")

--- a/features/appointments/build.gradle.kts
+++ b/features/appointments/build.gradle.kts
@@ -3,7 +3,6 @@ import build.BuildConfig
 import build.BuildDimensions
 import build.BuildTypes
 import extensions.getLocalProperty
-import extensions.osFamily
 import flavors.FlavorTypes
 import signing.SigningTypes
 import test.TestBuildConfig
@@ -31,7 +30,7 @@ android {
 
     signingConfigs {
         create(SigningTypes.RELEASE) {
-            storeFile = file(project.getLocalProperty("release_key.store.$osFamily"))
+            storeFile = file(project.getLocalProperty("release_key.store"))
             storePassword = project.getLocalProperty("release_key.store_password")
             keyAlias = project.getLocalProperty("release_key.alias")
             keyPassword = project.getLocalProperty("release_key.key_password")
@@ -39,7 +38,7 @@ android {
             enableV2Signing = true
         }
         create(SigningTypes.RELEASE_EXTERNAL_QA) {
-            storeFile = file(project.getLocalProperty("qa_key.store.$osFamily"))
+            storeFile = file(project.getLocalProperty("qa_key.store"))
             storePassword = project.getLocalProperty("qa_key.store_password")
             keyAlias = project.getLocalProperty("qa_key.alias")
             keyPassword = project.getLocalProperty("qa_key.key_password")

--- a/features/auth/build.gradle.kts
+++ b/features/auth/build.gradle.kts
@@ -3,7 +3,6 @@ import build.BuildConfig
 import build.BuildDimensions
 import build.BuildTypes
 import extensions.getLocalProperty
-import extensions.osFamily
 import flavors.FlavorTypes
 import signing.SigningTypes
 import test.TestBuildConfig
@@ -31,7 +30,7 @@ android {
 
     signingConfigs {
         create(SigningTypes.RELEASE) {
-            storeFile = file(project.getLocalProperty("release_key.store.$osFamily"))
+            storeFile = file(project.getLocalProperty("release_key.store"))
             storePassword = project.getLocalProperty("release_key.store_password")
             keyAlias = project.getLocalProperty("release_key.alias")
             keyPassword = project.getLocalProperty("release_key.key_password")
@@ -39,7 +38,7 @@ android {
             enableV2Signing = true
         }
         create(SigningTypes.RELEASE_EXTERNAL_QA) {
-            storeFile = file(project.getLocalProperty("qa_key.store.$osFamily"))
+            storeFile = file(project.getLocalProperty("qa_key.store"))
             storePassword = project.getLocalProperty("qa_key.store_password")
             keyAlias = project.getLocalProperty("qa_key.alias")
             keyPassword = project.getLocalProperty("qa_key.key_password")

--- a/features/consultations/build.gradle.kts
+++ b/features/consultations/build.gradle.kts
@@ -3,7 +3,6 @@ import build.BuildConfig
 import build.BuildDimensions
 import build.BuildTypes
 import extensions.getLocalProperty
-import extensions.osFamily
 import flavors.FlavorTypes
 import signing.SigningTypes
 import test.TestBuildConfig
@@ -31,7 +30,7 @@ android {
 
     signingConfigs {
         create(SigningTypes.RELEASE) {
-            storeFile = file(project.getLocalProperty("release_key.store.$osFamily"))
+            storeFile = file(project.getLocalProperty("release_key.store"))
             storePassword = project.getLocalProperty("release_key.store_password")
             keyAlias = project.getLocalProperty("release_key.alias")
             keyPassword = project.getLocalProperty("release_key.key_password")
@@ -39,7 +38,7 @@ android {
             enableV2Signing = true
         }
         create(SigningTypes.RELEASE_EXTERNAL_QA) {
-            storeFile = file(project.getLocalProperty("qa_key.store.$osFamily"))
+            storeFile = file(project.getLocalProperty("qa_key.store"))
             storePassword = project.getLocalProperty("qa_key.store_password")
             keyAlias = project.getLocalProperty("qa_key.alias")
             keyPassword = project.getLocalProperty("qa_key.key_password")

--- a/features/home/build.gradle.kts
+++ b/features/home/build.gradle.kts
@@ -3,7 +3,6 @@ import build.BuildConfig
 import build.BuildDimensions
 import build.BuildTypes
 import extensions.getLocalProperty
-import extensions.osFamily
 import flavors.FlavorTypes
 import signing.SigningTypes
 import test.TestBuildConfig
@@ -31,7 +30,7 @@ android {
 
     signingConfigs {
         create(SigningTypes.RELEASE) {
-            storeFile = file(project.getLocalProperty("release_key.store.$osFamily"))
+            storeFile = file(project.getLocalProperty("release_key.store"))
             storePassword = project.getLocalProperty("release_key.store_password")
             keyAlias = project.getLocalProperty("release_key.alias")
             keyPassword = project.getLocalProperty("release_key.key_password")
@@ -39,7 +38,7 @@ android {
             enableV2Signing = true
         }
         create(SigningTypes.RELEASE_EXTERNAL_QA) {
-            storeFile = file(project.getLocalProperty("qa_key.store.$osFamily"))
+            storeFile = file(project.getLocalProperty("qa_key.store"))
             storePassword = project.getLocalProperty("qa_key.store_password")
             keyAlias = project.getLocalProperty("qa_key.alias")
             keyPassword = project.getLocalProperty("qa_key.key_password")

--- a/features/notifications/build.gradle.kts
+++ b/features/notifications/build.gradle.kts
@@ -3,7 +3,6 @@ import build.BuildConfig
 import build.BuildDimensions
 import build.BuildTypes
 import extensions.getLocalProperty
-import extensions.osFamily
 import flavors.FlavorTypes
 import signing.SigningTypes
 import test.TestBuildConfig
@@ -31,7 +30,7 @@ android {
 
     signingConfigs {
         create(SigningTypes.RELEASE) {
-            storeFile = file(project.getLocalProperty("release_key.store.$osFamily"))
+            storeFile = file(project.getLocalProperty("release_key.store"))
             storePassword = project.getLocalProperty("release_key.store_password")
             keyAlias = project.getLocalProperty("release_key.alias")
             keyPassword = project.getLocalProperty("release_key.key_password")
@@ -39,7 +38,7 @@ android {
             enableV2Signing = true
         }
         create(SigningTypes.RELEASE_EXTERNAL_QA) {
-            storeFile = file(project.getLocalProperty("qa_key.store.$osFamily"))
+            storeFile = file(project.getLocalProperty("qa_key.store"))
             storePassword = project.getLocalProperty("qa_key.store_password")
             keyAlias = project.getLocalProperty("qa_key.alias")
             keyPassword = project.getLocalProperty("qa_key.key_password")

--- a/features/on_boarding/build.gradle.kts
+++ b/features/on_boarding/build.gradle.kts
@@ -3,7 +3,6 @@ import build.BuildConfig
 import build.BuildDimensions
 import build.BuildTypes
 import extensions.getLocalProperty
-import extensions.osFamily
 import flavors.FlavorTypes
 import signing.SigningTypes
 import test.TestBuildConfig
@@ -31,7 +30,7 @@ android {
 
     signingConfigs {
         create(SigningTypes.RELEASE) {
-            storeFile = file(project.getLocalProperty("release_key.store.$osFamily"))
+            storeFile = file(project.getLocalProperty("release_key.store"))
             storePassword = project.getLocalProperty("release_key.store_password")
             keyAlias = project.getLocalProperty("release_key.alias")
             keyPassword = project.getLocalProperty("release_key.key_password")
@@ -39,7 +38,7 @@ android {
             enableV2Signing = true
         }
         create(SigningTypes.RELEASE_EXTERNAL_QA) {
-            storeFile = file(project.getLocalProperty("qa_key.store.$osFamily"))
+            storeFile = file(project.getLocalProperty("qa_key.store"))
             storePassword = project.getLocalProperty("qa_key.store_password")
             keyAlias = project.getLocalProperty("qa_key.alias")
             keyPassword = project.getLocalProperty("qa_key.key_password")

--- a/features/settings/build.gradle.kts
+++ b/features/settings/build.gradle.kts
@@ -3,7 +3,6 @@ import build.BuildConfig
 import build.BuildDimensions
 import build.BuildTypes
 import extensions.getLocalProperty
-import extensions.osFamily
 import flavors.FlavorTypes
 import signing.SigningTypes
 import test.TestBuildConfig
@@ -31,7 +30,7 @@ android {
 
     signingConfigs {
         create(SigningTypes.RELEASE) {
-            storeFile = file(project.getLocalProperty("release_key.store.$osFamily"))
+            storeFile = file(project.getLocalProperty("release_key.store"))
             storePassword = project.getLocalProperty("release_key.store_password")
             keyAlias = project.getLocalProperty("release_key.alias")
             keyPassword = project.getLocalProperty("release_key.key_password")
@@ -39,7 +38,7 @@ android {
             enableV2Signing = true
         }
         create(SigningTypes.RELEASE_EXTERNAL_QA) {
-            storeFile = file(project.getLocalProperty("qa_key.store.$osFamily"))
+            storeFile = file(project.getLocalProperty("qa_key.store"))
             storePassword = project.getLocalProperty("qa_key.store_password")
             keyAlias = project.getLocalProperty("qa_key.alias")
             keyPassword = project.getLocalProperty("qa_key.key_password")


### PR DESCRIPTION
This commit simplifies the keystore path retrieval by removing the OS-family-specific logic. The `osFamily` extension property has been removed from `buildSrc/src/main/kotlin/extensions/Extensions.kt`.

All module-level `build.gradle.kts` files have been updated to directly use `release_key.store` and `qa_key.store` properties from `local.properties` without appending the OS family.

This change assumes that the `release_key.store` and `qa_key.store` properties in `local.properties` now point to the correct keystore file regardless of the operating system.