### PR TITLE
chore: Update Gradle Wrapper, Refactor Kotlin Config, and General Maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ICare
 
-[![Kotlin](https://img.shields.io/badge/Kotlin-2.2.0-blue.svg?style=flat&logo=kotlin)](https://kotlinlang.org)
+[![Kotlin](https://img.shields.io/badge/Kotlin-2.3.0-blue.svg?style=flat&logo=kotlin)](https://kotlinlang.org)
 [![Github Actions](https://github.com/dev-ali-mansour/Icare/actions/workflows/pull_request.yml/badge.svg)](https://github.com/dev-ali-mansour/Icare/actions/workflows/pull_request.yml)
 [![Apache 2 License](https://img.shields.io/github/license/InsertKoinIO/koin)](https://github.com/dev-ali-mansour/Icare?tab=Apache-2.0-1-ov-file)
 
@@ -48,7 +48,7 @@ icare/
 │   ├── consultation/         # consultation-related views and actions
 │   ├── home/                 # Home Screen and navigation
 │   ├── notifications/        # push notifications and alerts
-│   ├── on_boarding/          # On boarding screens
+│   ├── onboarding/           # Onboarding screens
 │   └── settings/             # User settings and preferences
 └── build.gradle.kts          # Modular Gradle configuration
 

--- a/build-logic/convention/src/main/kotlin/dev/alimansour/shared/plugins/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/dev/alimansour/shared/plugins/KotlinAndroid.kt
@@ -26,7 +26,9 @@ import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinBaseExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 
 internal fun Project.configureKotlinAndroid(commonExtension: CommonExtension) {
     commonExtension.apply {
@@ -50,7 +52,7 @@ internal fun Project.configureKotlinAndroid(commonExtension: CommonExtension) {
         }
     }
 
-    configureBaseKotlinCompilerOptions()
+    configureKotlin<KotlinAndroidProjectExtension>()
 
     dependencies {
         "implementation"(libs.findLibrary("coroutine.core").get())
@@ -71,32 +73,45 @@ internal fun Project.configureKotlinJvm() {
         targetCompatibility = JavaVersion.VERSION_21
     }
 
-    configureBaseKotlinCompilerOptions()
+    configureKotlin<KotlinJvmProjectExtension>()
 }
 
-private fun Project.configureBaseKotlinCompilerOptions() {
-    val configure: Project.() -> Unit = {
+private inline fun <reified T : KotlinBaseExtension> Project.configureKotlin() =
+    configure<T> {
+        // Treat all Kotlin warnings as errors (disabled by default)
+        // Override by setting warningsAsErrors=true in your ~/.gradle/gradle.properties
         val warningsAsErrors =
             providers
                 .gradleProperty("warningsAsErrors")
-                .map { it.toBoolean() }
-                .orElse(false)
-
-        tasks.withType(KotlinCompile::class.java).configureEach {
+                .map {
+                    it.toBoolean()
+                }.orElse(false)
+        when (this) {
+            is KotlinAndroidProjectExtension -> compilerOptions
+            is KotlinJvmProjectExtension -> compilerOptions
+            else -> TODO("Unsupported project extension $this ${T::class}")
+        }.apply {
             compilerOptions {
                 jvmTarget.set(JvmTarget.JVM_21)
                 allWarningsAsErrors.set(warningsAsErrors)
-                freeCompilerArgs.add("-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi")
                 freeCompilerArgs.add(
-                    // Remove this arg after Phase 3.
-                    // https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-consistent-copy-visibility/#deprecation-timeline
+                    // Enable experimental coroutines APIs, including Flow
+                    "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
+                )
+                freeCompilerArgs.add(
+                    /*
+                     * Remove this args after Phase 3.
+                     * https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-consistent-copy-visibility/#deprecation-timeline
+                     *
+                     * Deprecation timeline
+                     * Phase 3. (Supposedly Kotlin 2.2 or Kotlin 2.3).
+                     * The default changes.
+                     * Unless ExposedCopyVisibility is used, the generated 'copy' method has the same visibility as the primary constructor.
+                     * The binary signature changes. The error on the declaration is no longer reported.
+                     * '-Xconsistent-data-class-copy-visibility' compiler flag and ConsistentCopyVisibility annotation are now unnecessary.
+                     */
                     "-Xconsistent-data-class-copy-visibility",
                 )
             }
         }
     }
-
-    pluginManager.withPlugin("org.jetbrains.kotlin.android") { configure() }
-    pluginManager.withPlugin("org.jetbrains.kotlin.jvm") { configure() }
-    pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform") { configure() }
-}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
This PR updates repo tooling and docs by bumping Kotlin to `2.3.0`, updating the Gradle Wrapper to `9.3.1`, correcting the onboarding directory name in the README, and refactoring Kotlin compiler options configuration in `build-logic`.

## Changes
- **docs:** Update Kotlin version to `2.3.0` and fix the onboarding directory name in README.
- **chore:** Update Gradle Wrapper to `9.3.1`.
- **chore:** Refactor Kotlin compiler options configuration under `build-logic` to centralize compiler settings and reduce duplication.

## Notes
- No intended runtime behavior changes; build tooling and documentation updates only.

## Verification
- `./gradlew build`